### PR TITLE
Clamp parsed wear, sticker, and keychain values to valid ranges

### DIFF
--- a/src/parse-gc-inventory-item.test.ts
+++ b/src/parse-gc-inventory-item.test.ts
@@ -1,0 +1,143 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Ian Lucas. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+    CS2Economy,
+    CS2_ITEMS,
+    CS2_MAX_KEYCHAIN_SEED,
+    CS2_MAX_STICKER_ROTATION,
+    CS2_MAX_STICKER_WEAR,
+    CS2_MIN_STICKER_ROTATION,
+    CS2_MIN_STICKER_WEAR
+} from "@ianlucas/cs2-lib";
+import { english } from "@ianlucas/cs2-lib/translations";
+import { describe, expect, test } from "vitest";
+import { type CS2GCInventoryItem, parseGCInventoryItem } from "./parse-gc-inventory-item.js";
+
+CS2Economy.use({ items: CS2_ITEMS, language: english });
+
+const BROKEN_FANG_GLOVES_JADE_ID = 1707; // def 4725, index 10085, wear [0.06, 0.8]
+const GLOVES_DEFINDEX = 4725;
+const GLOVES_PAINTINDEX = 10085;
+const AWP_DRAGON_LORE_ID = 307; // def 9, index 344
+const AWP_DEFINDEX = 9;
+const AWP_PAINTINDEX = 344;
+const FALLEN_COLOGNE_STICKER_INDEX = 395; // sticker id 2226
+const LIL_AVA_KEYCHAIN_INDEX = 1; // keychain id 13113, def 1355
+
+function gcItem(overrides: Partial<CS2GCInventoryItem>): CS2GCInventoryItem {
+    return { defindex: 0, stickers: [], keychains: [], ...overrides };
+}
+
+describe("parseGCInventoryItem wear clamping", () => {
+    test("float below wearMin is clamped up to wearMin", () => {
+        const economyItem = CS2Economy.getById(BROKEN_FANG_GLOVES_JADE_ID);
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({ defindex: GLOVES_DEFINDEX, paintindex: GLOVES_PAINTINDEX, floatvalue: 0.01 })
+        );
+        expect(result.id).toBe(BROKEN_FANG_GLOVES_JADE_ID);
+        expect(result.wear).toBe(economyItem.getMinimumWear());
+    });
+
+    test("float above wearMax is clamped down to wearMax", () => {
+        const economyItem = CS2Economy.getById(BROKEN_FANG_GLOVES_JADE_ID);
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({ defindex: GLOVES_DEFINDEX, paintindex: GLOVES_PAINTINDEX, floatvalue: 0.95 })
+        );
+        expect(result.id).toBe(BROKEN_FANG_GLOVES_JADE_ID);
+        expect(result.wear).toBe(economyItem.getMaximumWear());
+    });
+});
+
+describe("parseGCInventoryItem sticker clamping", () => {
+    test("out-of-range sticker rotation is normalized into [min, max]", () => {
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: AWP_DEFINDEX,
+                paintindex: AWP_PAINTINDEX,
+                stickers: [{ slot: 0, stickerId: FALLEN_COLOGNE_STICKER_INDEX, rotation: 9999 }]
+            })
+        );
+        expect(result.id).toBe(AWP_DRAGON_LORE_ID);
+        const rotation = result.stickers?.[0]?.rotation;
+        expect(rotation).toBeGreaterThanOrEqual(CS2_MIN_STICKER_ROTATION);
+        expect(rotation).toBeLessThanOrEqual(CS2_MAX_STICKER_ROTATION);
+    });
+
+    test("over-max sticker wear is clamped to max", () => {
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: AWP_DEFINDEX,
+                paintindex: AWP_PAINTINDEX,
+                stickers: [{ slot: 0, stickerId: FALLEN_COLOGNE_STICKER_INDEX, wear: 5 }]
+            })
+        );
+        expect(result.id).toBe(AWP_DRAGON_LORE_ID);
+        expect(result.stickers?.[0]?.wear).toBe(CS2_MAX_STICKER_WEAR);
+    });
+
+    test("below-min sticker wear is clamped to min", () => {
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: AWP_DEFINDEX,
+                paintindex: AWP_PAINTINDEX,
+                stickers: [{ slot: 0, stickerId: FALLEN_COLOGNE_STICKER_INDEX, wear: -5 }]
+            })
+        );
+        // CS2_MIN_STICKER_WEAR is stripped to undefined by stripMinValues.
+        expect(result.stickers?.[0]?.wear).toBe(CS2_MIN_STICKER_WEAR === 0 ? undefined : CS2_MIN_STICKER_WEAR);
+    });
+});
+
+describe("parseGCInventoryItem keychain clamping", () => {
+    test("over-range nested keychain seed is clamped to max", () => {
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: AWP_DEFINDEX,
+                paintindex: AWP_PAINTINDEX,
+                keychains: [{ slot: 0, stickerId: LIL_AVA_KEYCHAIN_INDEX, pattern: 999999 }]
+            })
+        );
+        expect(result.id).toBe(AWP_DRAGON_LORE_ID);
+        expect(result.keychains?.[0]?.seed).toBe(CS2_MAX_KEYCHAIN_SEED);
+    });
+
+    test("out-of-range keychain item seed is clamped to max", () => {
+        const economyItem = CS2Economy.itemsAsArray.find(
+            (item) => item.isKeychain() && item.index === LIL_AVA_KEYCHAIN_INDEX && item.stickerIndex === undefined
+        )!;
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: economyItem.def,
+                keychains: [{ slot: 0, stickerId: LIL_AVA_KEYCHAIN_INDEX, pattern: 999999 }]
+            })
+        );
+        expect(result.id).toBe(economyItem.id);
+        expect(result.seed).toBe(CS2_MAX_KEYCHAIN_SEED);
+    });
+
+    test("below-min keychain item seed is clamped then stripped to undefined", () => {
+        const economyItem = CS2Economy.itemsAsArray.find(
+            (item) => item.isKeychain() && item.index === LIL_AVA_KEYCHAIN_INDEX && item.stickerIndex === undefined
+        )!;
+        const result = parseGCInventoryItem(
+            CS2Economy,
+            gcItem({
+                defindex: economyItem.def,
+                keychains: [{ slot: 0, stickerId: LIL_AVA_KEYCHAIN_INDEX, pattern: 0 }]
+            })
+        );
+        // Clamped up to CS2_MIN_KEYCHAIN_SEED, which stripMinValues then drops.
+        expect(result.id).toBe(economyItem.id);
+        expect(result.seed).toBeUndefined();
+    });
+});

--- a/src/parse-gc-inventory-item.ts
+++ b/src/parse-gc-inventory-item.ts
@@ -6,6 +6,9 @@
 import {
     type CS2BaseInventoryItem,
     CS2EconomyInstance,
+    CS2_MAX_KEYCHAIN_SEED,
+    CS2_MAX_STICKER_ROTATION,
+    CS2_MAX_STICKER_WEAR,
     CS2_MIN_KEYCHAIN_SEED,
     CS2_MIN_SEED,
     CS2_MIN_STICKER_ROTATION,
@@ -17,7 +20,7 @@ import {
     ensure
 } from "@ianlucas/cs2-lib";
 import { CS2_PREVIEW_HAS_STICKERS } from "./constants.js";
-import { truncate } from "./utils.js";
+import { clamp, truncate } from "./utils.js";
 
 export interface CS2GCInventoryItemSticker {
     slot?: number;
@@ -76,15 +79,23 @@ export function parseGCInventoryItem(economy: CS2EconomyInstance, data: CS2GCInv
         }
         assert(economyItem !== undefined);
         if (economyItem.isKeychain()) {
+            const seed = keychains[0]?.pattern ?? paintseed;
             return stripMinValues({
                 id: economyItem.id,
-                seed: keychains[0]?.pattern ?? paintseed
+                seed: seed !== undefined ? clamp(seed, CS2_MIN_KEYCHAIN_SEED, CS2_MAX_KEYCHAIN_SEED) : undefined
             });
         }
         return stripMinValues({
             id: economyItem.id,
             seed: economyItem.hasSeed() ? paintseed : undefined,
-            wear: economyItem.hasWear() && floatvalue !== undefined ? truncate(floatvalue, CS2_WEAR_FACTOR) : undefined,
+            wear:
+                economyItem.hasWear() && floatvalue !== undefined
+                    ? clamp(
+                          truncate(floatvalue, CS2_WEAR_FACTOR),
+                          economyItem.getMinimumWear(),
+                          economyItem.getMaximumWear()
+                      )
+                    : undefined,
             statTrak: economyItem.hasStatTrak() ? killeatervalue : undefined,
             nameTag: economyItem.hasNametag() ? customname : undefined,
             keychains:
@@ -101,7 +112,10 @@ export function parseGCInventoryItem(economy: CS2EconomyInstance, data: CS2GCInv
                                               item.stickerIndex === wrappedSticker
                                       )?.id
                                   ),
-                                  seed: pattern,
+                                  seed:
+                                      pattern !== undefined
+                                          ? clamp(pattern, CS2_MIN_KEYCHAIN_SEED, CS2_MAX_KEYCHAIN_SEED)
+                                          : undefined,
                                   x: offsetX,
                                   y: offsetY,
                                   z: offsetZ
@@ -120,9 +134,22 @@ export function parseGCInventoryItem(economy: CS2EconomyInstance, data: CS2GCInv
                                           ?.id
                                   ),
                                   rotation:
-                                      rotation !== undefined ? ((Math.trunc(rotation) % 360) + 360) % 360 : undefined,
+                                      rotation !== undefined
+                                          ? clamp(
+                                                ((Math.trunc(rotation) % 360) + 360) % 360,
+                                                CS2_MIN_STICKER_ROTATION,
+                                                CS2_MAX_STICKER_ROTATION
+                                            )
+                                          : undefined,
                                   schema: slot,
-                                  wear: wear !== undefined ? truncate(wear, CS2_STICKER_WEAR_FACTOR) : undefined,
+                                  wear:
+                                      wear !== undefined
+                                          ? clamp(
+                                                truncate(wear, CS2_STICKER_WEAR_FACTOR),
+                                                CS2_MIN_STICKER_WEAR,
+                                                CS2_MAX_STICKER_WEAR
+                                            )
+                                          : undefined,
                                   x: offsetX,
                                   y: offsetY
                               }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,3 +20,7 @@ export function bytesToFloat(byteValue: number) {
 export function truncate(value: number, factor: number) {
     return parseFloat(String(value).substring(0, String(factor).length));
 }
+
+export function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}


### PR DESCRIPTION
parseGCInventoryItem now clamps item wear to [wearMin, wearMax] and nested sticker wear/rotation and keychain seeds to their bounds, so out-of-range attributes can no longer brick inventories on load.
